### PR TITLE
Fix non updating shaders on linux

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -25,6 +25,7 @@ project "Application"
 
 	-- copy a file from the objects directory to the target directory
 	postbuildcommands 	{
+	"{RMDIR} %{cfg.targetdir}/resources",
 	"{COPY} resources %{cfg.targetdir}/resources"}
 
 	filter "system:windows"


### PR DESCRIPTION
If the resource folder already exists in Linux, it gets copied inside of the resources folder which means a separate path that isn't used by the program.  
That means that shaders won't update until the first resources folder in bin gets deleted.